### PR TITLE
Fixed 'redirect_uri' parameter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install
   --client_id 0oahdifc72URh7rUV0h7 \
   --okta_org https://micah.oktapreview.com \
   --scopes "openid profile email" \
-  --redirect_uri http://localhost:8080/redirect 
+  --redirect_uri /redirect
 ```
 
 You'll get output like this:


### PR DESCRIPTION
Hi @dogeared!

Thanks for this -- it was useful in debugging my authentication flow. I spotted this small error in the README that I wanted to fix for the next guy.

Turns out that if you provide the fully qualified URI, you get an error message because `server.get` only accepts a path, not a hostname (and indeed the port is [already configured](https://github.com/dogeared/pkce-cli/blob/master/pkce-cli#L34)):

```
$ ./pkce-cli --client_id REDACTED --okta_org REDACTED --scopes "openid profile email" --redirect_uri http://localhost:8080/redirect

assert.js:339
    throw err;
    ^

AssertionError [ERR_ASSERTION]: The first character of a path should be `/` or `*`
    at Router.on (/home/jgorset/code/pkce-cli/node_modules/find-my-way/index.js:62:3)
    at RouterRegistryRadix.add (/home/jgorset/code/pkce-cli/node_modules/restify/lib/routerRegistryRadix.js:42:21)
    at Router.mount (/home/jgorset/code/pkce-cli/node_modules/restify/lib/router.js:163:20)
    at Server.serverMethod [as get] (/home/jgorset/code/pkce-cli/node_modules/restify/lib/server.js:1548:33)
    at Object.<anonymous> (/home/jgorset/code/pkce-cli/pkce-cli:36:8)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```